### PR TITLE
Add parenthesis to totalEstimate check

### DIFF
--- a/src/main/resources/views/fragment.ftl.html
+++ b/src/main/resources/views/fragment.ftl.html
@@ -38,7 +38,7 @@
   <p>
     <%= datasource.getTitle() %> contains
     <span property="void:triples hydra:totalItems" datatype="xsd:integer" content="0">
-      no <#if totalEstimate > 0 >more</#if>
+      no <#if (totalEstimate > 0) >more</#if>
     </span>
     triples that match this pattern.
   </p>


### PR DESCRIPTION
If there are no triples that match the fragment, the Freemarker template throws an error in testing totalEstimate, as it thinks the <#if> tag is closed too early.
